### PR TITLE
Bugfix/add cors to dispatch cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
-  - pear install pear/PHP_CodeSniffer
+  - wget http://pear2.php.net/pyrus.phar
+  - php pyrus.phar
+  - pyrus install pear/PHP_CodeSniffer
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_script:
   - composer self-update
   - composer install --dev --prefer-source
   - wget http://pear2.php.net/pyrus.phar
-  - php pyrus.phar
-  - pyrus install pear/PHP_CodeSniffer
+  - php pyrus.phar install pear/PHP_CodeSniffer
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - composer install --dev --prefer-source
   - composer global require "squizlabs/php_codesniffer=*"
   - export PATH=~/.composer/vendor/bin/:$PATH
-  - phpenv rehash
 
 script:
   phpunit -v &

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
-  - sudo pear install --alldeps php_codesniffer
+  - pear install --alldeps php_codesniffer
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
-  - pyrus install pear/PHP_CodeSniffer
+  - pear install pear/PHP_CodeSniffer
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
-  - pear config-set php_bin /usr/bin/php
-  - pear install --alldeps php_codesniffer
+  - composer global require "squizlabs/php_codesniffer=*"
+  - export PATH=~/.composer/vendor/bin/:$PATH
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
-  - wget http://pear2.php.net/pyrus.phar
-  - php pyrus.phar install pear/PHP_CodeSniffer
+  - sudo pear install --alldeps php_codesniffer
   - phpenv rehash
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
   - cd ../../../ && phpenv config-add ./tests/phalcon.ini
   - composer self-update
   - composer install --dev --prefer-source
+  - pear config-set php_bin /usr/bin/php
   - pear install --alldeps php_codesniffer
   - phpenv rehash
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "evaengine/eva-sms": "0.1.*"
   },
   "require-dev": {
-    "satooshi/php-coveralls": "dev-master"
+    "satooshi/php-coveralls": "dev-master",
+    "phpunit/phpunit": "5.5.*"
   },
   "suggest": {
     "ext-redis": "*",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "evaengine/eva-sms": "0.1.*"
   },
   "require-dev": {
-    "satooshi/php-coveralls": "dev-master",
+    "satooshi/php-coveralls": "1.x",
     "phpunit/phpunit": "4.8.*"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "satooshi/php-coveralls": "dev-master",
-    "phpunit/phpunit": "5.5.*"
+    "phpunit/phpunit": "4.8.*"
   },
   "suggest": {
     "ext-redis": "*",

--- a/src/EvaEngine/CLI/Output/ConsoleOutput.php
+++ b/src/EvaEngine/CLI/Output/ConsoleOutput.php
@@ -155,7 +155,6 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
             $this->writeln($v);
         }
         $this->writeln("");
-
     }
 
     private function getSpace($length)

--- a/src/EvaEngine/Engine.php
+++ b/src/EvaEngine/Engine.php
@@ -1264,7 +1264,6 @@ class Engine
     {
         $config = $this->getDI()->getConfig()->cors;
         return new Cors($config->toArray());
-
     }
 
 

--- a/src/EvaEngine/Engine.php
+++ b/src/EvaEngine/Engine.php
@@ -13,6 +13,7 @@ use Eva\EvaEngine\CLI\Output\ConsoleOutput;
 //use Eva\EvaEngine\Events\DispatchCacheListener;
 use Eva\EvaEngine\Interceptor\Dispatch as DispatchInterceptor;
 use Eva\EvaEngine\SDK\SendCloudMailer;
+use Eva\EvaEngine\Service\Cors;
 use Eva\EvaSms\Sender;
 use Phalcon\CLI\Console;
 use Phalcon\Mvc\Router;
@@ -745,6 +746,14 @@ class Engine
                 return new FileLogger($config->logger->path . 'error.log');
             }
         );
+
+        $di->set(
+            'cors',
+            function () use ($self) {
+                return $self->diCors();
+            }
+        );
+
         if ($this->appMode == 'cli') {
             $this->cliDI($di);
         }
@@ -1250,6 +1259,14 @@ class Engine
 
         return $filesystem;
     }
+
+    public function diCors()
+    {
+        $config = $this->getDI()->getConfig()->cors;
+        return new Cors($config->toArray());
+
+    }
+
 
     /**
      * Application Bootstrap, init DI, register Modules, init events, init ErrorHandler

--- a/src/EvaEngine/Error/CLIErrorHandler.php
+++ b/src/EvaEngine/Error/CLIErrorHandler.php
@@ -43,7 +43,6 @@ class CLIErrorHandler implements ErrorHandlerInterface
         $output->writeln("");
         $output->writelnWarning(' [WARNING]: '. $errstr.' in file '. $errfile .' at line '.$errline);
         $output->writeln("");
-
     }
 
     /**
@@ -55,7 +54,6 @@ class CLIErrorHandler implements ErrorHandlerInterface
         $output = new ConsoleOutput();
         $output->writelnError($e->getMessage());
         $output->writelnComment($e->getTraceAsString());
-
     }
 
     /**
@@ -146,7 +144,5 @@ class CLIErrorHandler implements ErrorHandlerInterface
         if (!$useErrorController) {
             return;
         }
-
-
     }
 }

--- a/src/EvaEngine/Exception/OriginNotAllowedException.php
+++ b/src/EvaEngine/Exception/OriginNotAllowedException.php
@@ -9,7 +9,10 @@
 
 namespace Eva\EvaEngine\Exception;
 
-
+/**
+ * Cors Origin Not Allowed Exception
+ * @package Eva\EvaEngine\Exception
+ */
 class OriginNotAllowedException extends StandardException
 {
     /**

--- a/src/EvaEngine/Exception/OriginNotAllowedException.php
+++ b/src/EvaEngine/Exception/OriginNotAllowedException.php
@@ -1,12 +1,10 @@
 <?php
 /**
- * Wscn
+ * EvaEngine (http://evaengine.com/)
+ * A development engine based on Phalcon Framework.
  *
- * @link: https://github.com/wallstreetcn/wallstreetcn
- * @author: franktung<franktung@gmail.com>
- * @Date: 16/9/30
- * @Time: 下午4:59
- *
+ * @copyright Copyright (c) 2014-2015 EvaEngine Team (https://github.com/EvaEngine/EvaEngine)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Eva\EvaEngine\Exception;

--- a/src/EvaEngine/Exception/OriginNotAllowedException.php
+++ b/src/EvaEngine/Exception/OriginNotAllowedException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Wscn
+ *
+ * @link: https://github.com/wallstreetcn/wallstreetcn
+ * @author: franktung<franktung@gmail.com>
+ * @Date: 16/9/30
+ * @Time: 下午4:59
+ *
+ */
+
+namespace Eva\EvaEngine\Exception;
+
+
+class OriginNotAllowedException extends StandardException
+{
+    /**
+     * @var int
+     */
+    protected $statusCode = 403;
+}

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -223,6 +223,7 @@ class Dispatch
                 'ignore_query_keys' => '_',
                 'jsonp_callback_key' => 'callback',
                 'format' => 'text', //allow text | jsonp
+                'cors_enabled' => false,
             ),
             $interceptorParams
         );
@@ -238,6 +239,8 @@ class Dispatch
         $ignoreQueryKeys = $interceptorParams['ignore_query_keys'] ?
             explode('|', $interceptorParams['ignore_query_keys']) : array();
         $interceptorParams['ignore_query_keys'] = $ignoreQueryKeys;
+
+        $interceptorParams['cors_enabled'] = (bool)$interceptorParams['cors_enabled'];
 
         return $interceptorParams;
     }
@@ -281,6 +284,11 @@ class Dispatch
 
         //cache key matched, response already prepared
         if (true === $interceptResult) {
+
+            if (true === $params['cors_enabled']) {     //$params
+                $di->getCors()->preflightedRequests();
+            }
+
             $di->getResponse()->send();
 
             return false;

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -284,7 +284,6 @@ class Dispatch
 
         //cache key matched, response already prepared
         if (true === $interceptResult) {
-
             if (true === $params['cors_enabled']) {     //$params
                 $di->getCors()->preflightRequests();
             }

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -138,7 +138,7 @@ class Dispatch
             $bodyCache = $cache->get($bodyKey);
             $headersCache = $cache->get($headersKey);
             $hasCache = $headersCache && $bodyCache;
-        }
+        } 
 
         if ($hasCache) {
             /**

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -286,7 +286,7 @@ class Dispatch
         if (true === $interceptResult) {
 
             if (true === $params['cors_enabled']) {     //$params
-                $di->getCors()->preflightedRequests();
+                $di->getCors()->preflightRequests();
             }
 
             $di->getResponse()->send();

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -138,7 +138,7 @@ class Dispatch
             $bodyCache = $cache->get($bodyKey);
             $headersCache = $cache->get($headersKey);
             $hasCache = $headersCache && $bodyCache;
-        } 
+        }
 
         if ($hasCache) {
             /**

--- a/src/EvaEngine/Interceptor/Dispatch.php
+++ b/src/EvaEngine/Interceptor/Dispatch.php
@@ -138,7 +138,7 @@ class Dispatch
             $bodyCache = $cache->get($bodyKey);
             $headersCache = $cache->get($headersKey);
             $hasCache = $headersCache && $bodyCache;
-        }else{
+        } else {
             // 要求刷新缓存时：先删了已有缓存，避免不正常退出时（如资源被移除）缓存未被刷新的情况。
             $cache->delete($headersKey);
         }

--- a/src/EvaEngine/Mvc/Controller/ControllerBase.php
+++ b/src/EvaEngine/Mvc/Controller/ControllerBase.php
@@ -279,7 +279,6 @@ class ControllerBase extends Controller
             $exception->getTraceAsString()
         );
         */
-
     }
 
     /**

--- a/src/EvaEngine/Mvc/Model.php
+++ b/src/EvaEngine/Mvc/Model.php
@@ -130,7 +130,6 @@ class Model extends PhalconModel
                 } else {
                     $data[$key] = null;
                 }
-
             } elseif (is_string($subdata)) {
                 $data[$key] = $this->$subdata();
             }

--- a/src/EvaEngine/SDK/SendCloudMailer.php
+++ b/src/EvaEngine/SDK/SendCloudMailer.php
@@ -38,7 +38,6 @@ class SendCloudMailer
      */
     public function setPort($port)
     {
-
     }
 
     public function setUsername($username)

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * EvaEngine (http://evaengine.com/)
+ * A development engine based on Phalcon Framework.
+ *
+ * @copyright Copyright (c) 2014-2015 EvaEngine Team (https://github.com/EvaEngine/EvaEngine)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Eva\EvaEngine\Service;
+
+
+use Phalcon\DI\InjectionAwareInterface;
+
+class Cors implements InjectionAwareInterface
+{
+
+    protected $_di;
+
+    protected $config;
+    
+    public function __construct($config)
+    {
+        $this->setConfig($config);
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    public function setConfig($config)
+    {
+        $this->config = $config;
+    }
+
+    public function setDI($di)
+    {
+        $this->_di = $di;
+    }
+
+    public function getDI()
+    {
+        return $this->_di;
+    }
+
+    public function simpleRequests()
+    {
+        if ($this->ifHttpOriginIsInTheWhiteList()) {
+            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+        }
+    }
+
+    public function preflightedRequests(
+        $allowCredentials = 'true',
+        $allowMethods = 'GET, POST, PUT, DELETE, OPTIONS',
+        $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma,'
+        . 'Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With, Content-Type'
+    )
+    {
+        if ($this->ifHttpOriginIsInTheWhiteList()) {
+            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Credentials', (string)$allowCredentials);
+            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Methods', $allowMethods);
+            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Headers', $allowHeaders);
+            if (strtoupper($this->request->getMethod()) == 'OPTIONS') {
+                $this->response->send();
+                exit();
+            }
+        }
+    }
+
+    protected function ifHttpOriginIsInTheWhiteList()
+    {
+
+        $checked = false;
+        foreach ($this->config as $domain) {
+            if (ends_with($_SERVER['HTTP_ORIGIN'], $domain['domain'])) {
+                $checked = true;
+            }
+        }
+        return $checked;
+    }
+
+}

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -47,6 +47,10 @@ class Cors implements InjectionAwareInterface
 
     public function simpleRequests()
     {
+        // TODO: Host == Origin
+        if (empty($_SERVER['HTTP_ORIGIN'])) {
+            return;
+        }
         if (! $this->ifHttpOriginIsInTheWhiteList()) {
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
@@ -60,6 +64,9 @@ class Cors implements InjectionAwareInterface
         . 'Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With, Content-Type'
     )
     {
+        if (empty($_SERVER['HTTP_ORIGIN'])) {
+            return;
+        }
         if (! $this->ifHttpOriginIsInTheWhiteList()) {
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -46,13 +46,13 @@ class Cors implements InjectionAwareInterface
 
     public function simpleRequests()
     {
-        if (empty($_SERVER['HTTP_ORIGIN'])) {
+        if (empty($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'))) {
             return;
         }
-        if ($this->ifOriginIsSameAsHost()) {
+        if ($this->isOriginIsSameAsHost()) {
             return;
         }
-        if (! $this->ifHttpOriginIsInTheWhiteList()) {
+        if (! $this->isHttpOriginIsInTheWhiteList()) {
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
         $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
@@ -63,14 +63,14 @@ class Cors implements InjectionAwareInterface
         $allowMethods = 'GET, POST, PUT, DELETE, OPTIONS',
         $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma, Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With'
     ) {
-        if (empty($_SERVER['HTTP_ORIGIN'])) {
+        if (empty($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'))) {
             return;
         }
-        if ($this->ifOriginIsSameAsHost()) {
+        if ($this->isOriginIsSameAsHost()) {
             return;
         }
 
-        if (! $this->ifHttpOriginIsInTheWhiteList()) {
+        if (! $this->isHttpOriginIsInTheWhiteList()) {
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
         $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Credentials', (string)$allowCredentials);
@@ -83,7 +83,7 @@ class Cors implements InjectionAwareInterface
         }
     }
 
-    protected function ifHttpOriginIsInTheWhiteList()
+    protected function isHttpOriginIsInTheWhiteList()
     {
         $checked = false;
         foreach ($this->config as $domain) {
@@ -96,7 +96,7 @@ class Cors implements InjectionAwareInterface
         return $checked;
     }
 
-    public function ifOriginIsSameAsHost()
+    public function isOriginIsSameAsHost()
     {
         $originDomainArray = explode('.', parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST));
         $hostDomainArray = explode('.', $_SERVER['HTTP_HOST']);

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -62,8 +62,7 @@ class Cors implements InjectionAwareInterface
     public function preflightRequests(
         $allowCredentials = 'true',
         $allowMethods = 'GET, POST, PUT, DELETE, OPTIONS',
-        $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma,'
-        . 'Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With'
+        $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma, Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With'
     )
     {
         if (empty($_SERVER['HTTP_ORIGIN'])) {

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -63,8 +63,8 @@ class Cors implements InjectionAwareInterface
             $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
             $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Methods', $allowMethods);
             $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Headers', $allowHeaders);
-            if (strtoupper($this->request->getMethod()) == 'OPTIONS') {
-                $this->response->send();
+            if (strtoupper($this->getDI()->getRequest()->getMethod()) == 'OPTIONS') {
+                $this->getDI()->getResponse()->send();
                 exit();
             }
         }

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -10,6 +10,7 @@
 namespace Eva\EvaEngine\Service;
 
 
+use Eva\EvaEngine\Exception\OriginNotAllowedException;
 use Phalcon\DI\InjectionAwareInterface;
 
 class Cors implements InjectionAwareInterface
@@ -46,9 +47,10 @@ class Cors implements InjectionAwareInterface
 
     public function simpleRequests()
     {
-        if ($this->ifHttpOriginIsInTheWhiteList()) {
-            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+        if (! $this->ifHttpOriginIsInTheWhiteList()) {
+            throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
     }
 
     public function preflightedRequests(
@@ -58,15 +60,16 @@ class Cors implements InjectionAwareInterface
         . 'Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With, Content-Type'
     )
     {
-        if ($this->ifHttpOriginIsInTheWhiteList()) {
-            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Credentials', (string)$allowCredentials);
-            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
-            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Methods', $allowMethods);
-            $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Headers', $allowHeaders);
-            if (strtoupper($this->getDI()->getRequest()->getMethod()) == 'OPTIONS') {
-                $this->getDI()->getResponse()->send();
-                exit();
-            }
+        if (! $this->ifHttpOriginIsInTheWhiteList()) {
+            throw new OriginNotAllowedException('Http Origin Is Not Allowed');
+        }
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Credentials', (string)$allowCredentials);
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Methods', $allowMethods);
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Headers', $allowHeaders);
+        if (strtoupper($this->getDI()->getRequest()->getMethod()) == 'OPTIONS') {
+            $this->getDI()->getResponse()->send();
+            exit();
         }
     }
 

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -46,7 +46,8 @@ class Cors implements InjectionAwareInterface
 
     public function simpleRequests()
     {
-        if (empty($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'))) {
+        $httpOrigin = $this->getDI()->getRequest()->getHeader('HTTP_ORIGIN');
+        if (empty($httpOrigin)) {
             return;
         }
         if ($this->isOriginIsSameAsHost()) {
@@ -55,7 +56,7 @@ class Cors implements InjectionAwareInterface
         if (! $this->isHttpOriginIsInTheWhiteList()) {
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
-        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $httpOrigin);
     }
 
     public function preflightRequests(
@@ -63,7 +64,8 @@ class Cors implements InjectionAwareInterface
         $allowMethods = 'GET, POST, PUT, DELETE, OPTIONS',
         $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma, Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With'
     ) {
-        if (empty($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'))) {
+        $httpOrigin = $this->getDI()->getRequest()->getHeader('HTTP_ORIGIN');
+        if (empty($httpOrigin)) {
             return;
         }
         if ($this->isOriginIsSameAsHost()) {
@@ -74,7 +76,7 @@ class Cors implements InjectionAwareInterface
             throw new OriginNotAllowedException('Http Origin Is Not Allowed');
         }
         $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Credentials', (string)$allowCredentials);
-        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+        $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Origin', $httpOrigin);
         $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Methods', $allowMethods);
         $this->getDI()->getResponse()->setHeader('Access-Control-Allow-Headers', $allowHeaders);
         if (strtoupper($this->getDI()->getRequest()->getMethod()) == 'OPTIONS') {
@@ -87,7 +89,7 @@ class Cors implements InjectionAwareInterface
     {
         $checked = false;
         foreach ($this->config as $domain) {
-            $originDomainArray = explode('.', parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST));
+            $originDomainArray = explode('.', parse_url($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'), PHP_URL_HOST));
             $allowedDomainArray = explode('.', $domain['domain']);
             if (! (count($allowedDomainArray) > count($originDomainArray)) && ! array_diff($allowedDomainArray, $originDomainArray)) {
                 $checked = true;
@@ -98,8 +100,8 @@ class Cors implements InjectionAwareInterface
 
     public function isOriginIsSameAsHost()
     {
-        $originDomainArray = explode('.', parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST));
-        $hostDomainArray = explode('.', $_SERVER['HTTP_HOST']);
+        $originDomainArray = explode('.', parse_url($this->getDI()->getRequest()->getHeader('HTTP_ORIGIN'), PHP_URL_HOST));
+        $hostDomainArray = explode('.', $this->getDI()->getRequest()->getHeader('HTTP_HOST'));
         if (! (count($hostDomainArray) > count($originDomainArray)) && ! array_diff($hostDomainArray, $originDomainArray)) {
             return true;
         }

--- a/src/EvaEngine/Service/Cors.php
+++ b/src/EvaEngine/Service/Cors.php
@@ -9,7 +9,6 @@
 
 namespace Eva\EvaEngine\Service;
 
-
 use Eva\EvaEngine\Exception\OriginNotAllowedException;
 use Phalcon\DI\InjectionAwareInterface;
 
@@ -63,8 +62,7 @@ class Cors implements InjectionAwareInterface
         $allowCredentials = 'true',
         $allowMethods = 'GET, POST, PUT, DELETE, OPTIONS',
         $allowHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma, Last-Modified, Cache-Control, Expires, Content-Type, X-E4M-With'
-    )
-    {
+    ) {
         if (empty($_SERVER['HTTP_ORIGIN'])) {
             return;
         }
@@ -107,6 +105,4 @@ class Cors implements InjectionAwareInterface
         }
         return false;
     }
-
-
 }

--- a/src/EvaEngine/Tasks/MainTask.php
+++ b/src/EvaEngine/Tasks/MainTask.php
@@ -27,7 +27,6 @@ class MainTask extends TaskBase
         $this->output->writelnError("------------------------------");
         var_dump(func_get_args());
         $this->output->writelnError("------------------------------");
-
     }
 
     public function helpAction($params)

--- a/tests/EvaEngineTest/Service/CorsTest.php
+++ b/tests/EvaEngineTest/Service/CorsTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Eva\EvaEngine\EvaEngineTest\Service;
+
+class CorsTest extends \PHPUnit_Framework_TestCase
+{
+    
+}

--- a/tests/EvaEngineTest/Service/CorsTest.php
+++ b/tests/EvaEngineTest/Service/CorsTest.php
@@ -2,27 +2,184 @@
 
 namespace Eva\EvaEngine\EvaEngineTest\Service;
 
+use Eva\EvaEngine\Engine;
+use Eva\EvaEngine\Service\Cors;
+use Phalcon\Events\Manager;
+use Phalcon\Config;
+use Phalcon\DI;
+use Phalcon\Http\Request;
+use Phalcon\Http\Response;
+use Phalcon\Mvc\Application;
+
 class CorsTest extends \PHPUnit_Framework_TestCase
 {
 
+    protected $request;
+
+    protected $response;
+
+    protected $di;
+
+    protected $application;
+
+    public function setUp()
+    {
+        $di = new DI();
+
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/path?foo=aaa&bar=bbb';
+        $_GET = array(
+            '_url' => '/path',
+            'foo' => 'aaa',
+            'bar' => 'bbb'
+        );
+        $request = new Request();
+        $request->setDI($di);
+        $this->request = $request;
+
+        $response = new Response();
+        $response->setDI($di);
+        $this->response = $response;
+
+        $eventsManager = new Manager();
+
+        $cors = new Cors(
+            array(
+                array(
+                    'domain' => 'bar.com'
+                )
+            )
+        );
+
+        $di->set('request', $request, true);
+        $di->set('response', $response, true);
+        $di->set('eventsManager', $eventsManager);
+
+        $di->set('cors', $cors);
+
+        $this->di = $di;
+
+        $application = new Application();
+        $application->setDI($di);
+        $application->setEventsManager($eventsManager);
+        $this->application = $application;
+    }
+
+    public function testBasicRequest()
+    {
+        $this->assertEquals($this->request->getHttpHost(), 'example.com');
+        $this->assertEquals(
+            $this->request->getQuery(),
+            array(
+                '_url' => '/path',
+                'foo' => 'aaa',
+                'bar' => 'bbb'
+            )
+        );
+        $this->assertEquals($this->request->getMethod(), 'GET');
+    }
+
     public function testItDoesNotModifyResponseOnARequestWithoutOrigin()
     {
-
+        $unmodifiedResponse = $this->response;
+        $this->application->getDI()->getCors()->preflightRequests();
+        $this->assertEquals($unmodifiedResponse->getHeaders(), $this->response->getHeaders());
     }
 
     public function testItDoesNotModifyResponseOnARequestWithSameOrigin()
     {
-
+        $unmodifiedResponse = $this->response;
+        $_SERVER['HTTP_ORIGIN'] = 'http://example.com';
+        $this->application->getDI()->getCors()->preflightRequests();
+        $this->assertEquals($unmodifiedResponse->getHeaders(), $this->response->getHeaders());
     }
-    
-    
-    public function testOriginNotAllowed()
+
+    /**
+     * @expectedException \Eva\EvaEngine\Exception\OriginNotAllowedException
+     */
+    public function testPreflightRequestWithOriginNotAllowed()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://foo.com';
+        $this->application->getDI()->getCors()->preflightRequests();
+    }
+
+    /**
+     * @expectedException \Eva\EvaEngine\Exception\OriginNotAllowedException
+     */
+    public function testSimpleRequestWithOriginNotAllowed()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://foo.com';
+        $this->application->getDI()->getCors()->simpleRequests();
+    }
+
+    public function testPreflightRequestWithRequestedHeadersAllowed()
     {
 
     }
 
-    public function testPreflightedRequestWithRequestedHeadersAllowed()
+    public function testSimpleRequestWithRequestedHeadersAllowed()
     {
 
     }
+
+    /**
+     * @expectedException \Eva\EvaEngine\Exception\OriginNotAllowedException
+     */
+    public function testItDoesNotReturnAllowOriginHeaderOnPreflightRequestWithOriginNotAllowed()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://api.foo.com';
+        $this->application->getDI()->getCors()->preflightRequests();
+        $headers = $this->response->getHeaders();
+        $this->assertFalse(isset($headers['Access-Control-Allow-Origin']));
+    }
+
+    /**
+     * @expectedException \Eva\EvaEngine\Exception\OriginNotAllowedException
+     */
+    public function testItDoesNotReturnAllowOriginHeaderOnSimpleRequestWithOriginNotAllowed()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://foo.com';
+        $this->application->getDI()->getCors()->simpleRequests();
+        $headers = $this->response->getHeaders();
+        $this->assertFalse(isset($headers['Access-Control-Allow-Origin']));
+    }
+
+    public function testItSetsAllowCredentialsHeaderOnValidActualRequestWhenFlagIsSetToTrue()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://bar.com';
+        $this->application->getDI()->getCors()->preflightRequests();
+        $this->assertEquals('true', $this->response->getHeaders()->get('Access-Control-Allow-Credentials'));
+    }
+
+    public function testItSetsAllowCredentialsHeaderOnValidActualRequestWhenFlagIsSetToFalse()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://bar.com';
+        $this->application->getDI()->getCors()->preflightRequests('false');
+        $this->assertEquals('false', $this->response->getHeaders()->get('Access-Control-Allow-Credentials'));
+    }
+
+    public function testItSetsAccessControlAllowOriginHeaderOnValidActualRequest()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://bar.com';
+        $this->application->getDI()->getCors()->preflightRequests();
+        $this->assertEquals($_SERVER['HTTP_ORIGIN'], $this->response->getHeaders()->get('Access-Control-Allow-Origin'));
+    }
+
+    public function testItSetsAccessControlAllowMethodsOnValidActualRequestWhenFlagIsSet()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://api-v2.bar.com';
+        $allowMethods = 'GET, POST, PUT';
+        $this->application->getDI()->getCors()->preflightRequests('true', $allowMethods);
+        $this->assertEquals($allowMethods, $this->response->getHeaders()->get('Access-Control-Allow-Methods'));
+    }
+
+    public function testItSetsAccessControlAllowHeadersOnValidActualRequestWhenFlagIsSet()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://bar.com';
+        $allowedHeaders = 'Origin, No-Cache, X-Requested-With, If-Modified-Since, Pragma';
+        $this->application->getDI()->getCors()->preflightRequests('true', 'GET, POST, PUT', $allowedHeaders);
+        $this->assertEquals($allowedHeaders, $this->response->getHeaders()->get('Access-Control-Allow-Headers'));
+    }
+
 }

--- a/tests/EvaEngineTest/Service/CorsTest.php
+++ b/tests/EvaEngineTest/Service/CorsTest.php
@@ -4,5 +4,25 @@ namespace Eva\EvaEngine\EvaEngineTest\Service;
 
 class CorsTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function testItDoesNotModifyResponseOnARequestWithoutOrigin()
+    {
+
+    }
+
+    public function testItDoesNotModifyResponseOnARequestWithSameOrigin()
+    {
+
+    }
     
+    
+    public function testOriginNotAllowed()
+    {
+
+    }
+
+    public function testPreflightedRequestWithRequestedHeadersAllowed()
+    {
+
+    }
 }


### PR DESCRIPTION
- 修复在击中dispatch cache时候，没有支持跨域的问题。通过将跨域作为服务注入DI，在class Dispatch中的injectInterceptor方法中调用
- 原有跨域白名单检测机制有漏洞，用ends_with方法检测时候，如果白名单的域名是foo.com，请求域名是barfoo.com时，还是能通过白名单
